### PR TITLE
Fix a write on read situation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- CSRF fix: safe write on read.
+  [gforcada]
 
 
 4.0.8 (2015-09-20)

--- a/plone/app/contentrules/browser/assignments.py
+++ b/plone/app/contentrules/browser/assignments.py
@@ -25,11 +25,11 @@ class ManageAssignments(BrowserView):
         request = aq_inner(self.request)
         form = request.form
         status = IStatusMessage(self.request)
-        assignable = IRuleAssignmentManager(context)
 
         operation = request.get('operation', None)
 
         if operation == 'move_up':
+            assignable = IRuleAssignmentManager(context)
             rule_id = request.get('rule_id')
             keys = list(assignable.keys())
             idx = keys.index(rule_id)
@@ -37,6 +37,7 @@ class ManageAssignments(BrowserView):
             keys.insert(idx - 1, rule_id)
             assignable.updateOrder(keys)
         elif operation == 'move_down':
+            assignable = IRuleAssignmentManager(context)
             rule_id = request.get('rule_id')
             keys = list(assignable.keys())
             idx = keys.index(rule_id)


### PR DESCRIPTION
Move the assignable where is actually needed, thus preventing a write on read.

Note that there is a possible vector for a write on read, see ``assigned_rules`` method, where it needs the assignable, but if that is not found it causes a write on read.

This last issue is fixed with https://github.com/plone/plone.contentrules/pull/2