### PR TITLE
Fix a write on read situation (Plone 4.3)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- CSRF fix: safe write on read.
+  [gforcada]
 
 
 3.0.8 (2014-10-22)

--- a/plone/app/contentrules/browser/assignments.py
+++ b/plone/app/contentrules/browser/assignments.py
@@ -25,11 +25,11 @@ class ManageAssignments(BrowserView):
         request = aq_inner(self.request)
         form = request.form
         status = IStatusMessage(self.request)
-        assignable = IRuleAssignmentManager(context)
 
         operation = request.get('operation', None)
 
         if operation == 'move_up':
+            assignable = IRuleAssignmentManager(context)
             rule_id = request.get('rule_id')
             keys = list(assignable.keys())
             idx = keys.index(rule_id)
@@ -37,6 +37,7 @@ class ManageAssignments(BrowserView):
             keys.insert(idx-1, rule_id)
             assignable.updateOrder(keys)
         elif operation == 'move_down':
+            assignable = IRuleAssignmentManager(context)
             rule_id = request.get('rule_id')
             keys = list(assignable.keys())
             idx = keys.index(rule_id)


### PR DESCRIPTION
Only get the rule management assignable if it's going to be used.

Getting it has the side effect of creating it if it does not exist,
thus causing a write on read.