### PR TITLE
Replace docstring mentions of Formlib with z3c.form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Fixes:
 - Use zope.interface decorator.
   [gforcada]
 
+- Replace docstring mentions of Formlib with z3c.form
+  [staeff]
 
 4.0.10 (2015-11-26)
 -------------------

--- a/plone/app/contentrules/actions/copy.py
+++ b/plone/app/contentrules/actions/copy.py
@@ -139,7 +139,7 @@ class CopyAddFormView(ContentRuleFormWrapper):
 class CopyEditForm(ActionEditForm):
     """An edit form for copy rule actions.
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = ICopyAction
     label = _(u"Edit Copy Action")

--- a/plone/app/contentrules/actions/logger.py
+++ b/plone/app/contentrules/actions/logger.py
@@ -111,7 +111,7 @@ class LoggerAddFormView(ContentRuleFormWrapper):
 class LoggerEditForm(ActionEditForm):
     """An edit form for logger rule actions.
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = ILoggerAction
     label = _(u"Edit Logger Action")

--- a/plone/app/contentrules/actions/move.py
+++ b/plone/app/contentrules/actions/move.py
@@ -163,7 +163,7 @@ class MoveAddFormView(ContentRuleFormWrapper):
 class MoveEditForm(ActionEditForm):
     """An edit form for move rule actions.
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = IMoveAction
     label = _(u"Edit Move Action")

--- a/plone/app/contentrules/actions/notify.py
+++ b/plone/app/contentrules/actions/notify.py
@@ -82,7 +82,7 @@ class NotifyAddFormView(ContentRuleFormWrapper):
 class NotifyEditForm(ActionEditForm):
     """An edit form for notify rule actions.
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = INotifyAction
     label = _(u"Edit Notify Action")

--- a/plone/app/contentrules/conditions/fileextension.py
+++ b/plone/app/contentrules/conditions/fileextension.py
@@ -93,7 +93,7 @@ class FileExtensionAddFormView(ContentRuleFormWrapper):
 class FileExtensionEditForm(EditForm):
     """An edit form for portal type conditions
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = IFileExtensionCondition
     label = _(u"Edit File Extension Condition")

--- a/plone/app/contentrules/conditions/wfstate.py
+++ b/plone/app/contentrules/conditions/wfstate.py
@@ -81,7 +81,7 @@ class WorkflowStateAddFormView(ContentRuleFormWrapper):
 class WorkflowStateEditForm(EditForm):
     """An edit form for portal type conditions
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = IWorkflowStateCondition
     label = _(u"Edit Workflow State Condition")

--- a/plone/app/contentrules/conditions/wftransition.py
+++ b/plone/app/contentrules/conditions/wftransition.py
@@ -76,7 +76,7 @@ class WorkflowTransitionAddFormView(ContentRuleFormWrapper):
 class WorkflowTransitionEditForm(EditForm):
     """An edit form for portal type conditions
 
-    Formlib does all the magic here.
+    z3c.form does all the magic here.
     """
     schema = IWorkflowTransitionCondition
     label = _(u"Edit Workflow Transition Condition")


### PR DESCRIPTION
p.a.contentrules replaces Formlib with z3c.form in version 4.0.5
Formlib was still mentioned in some docstrings, which are hereby
replaced with z3c.form