### PR TITLE
test fixes + import fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- In browser tests, specify the buttons to be clicked by their name instead of their index.
+  [thet]
+
 - Fix import location for Products.ATContentTypes.interfaces.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix import location for Products.ATContentTypes.interfaces.
+  [thet]
 
 
 4.0.12 (2016-11-10)

--- a/plone/app/contentrules/conditions/fileextension.py
+++ b/plone/app/contentrules/conditions/fileextension.py
@@ -7,7 +7,7 @@ from zope import schema
 
 from OFS.SimpleItem import SimpleItem
 try:
-    from Products.ATContentTypes.interface import IFileContent
+    from Products.ATContentTypes.interfaces import IFileContent
 except ImportError:
     IFileContent = None
 

--- a/plone/app/contentrules/tests/assignment.txt
+++ b/plone/app/contentrules/tests/assignment.txt
@@ -37,13 +37,13 @@ condition for *published*:
   'http://nohost/plone/++rule++rule-1/@@manage-elements'
   >>> browser.getControl('Add condition').value = [
   ...     'plone.conditions.PortalType']
-  >>> browser.getControl('Add', index=1).click()
+  >>> browser.getControl(name='form.button.AddCondition').click()
   >>> browser.getControl('Content type').value = ['News Item']
   >>> browser.getControl('Save').click()
 
   >>> browser.getControl('Add condition').value = [
   ...     'plone.conditions.WorkflowState']
-  >>> browser.getControl('Add', index=1).click()
+  >>> browser.getControl(name='form.button.AddCondition').click()
   >>> browser.getControl('Workflow state').value = ['published']
   >>> browser.getControl('Save').click()
 
@@ -51,7 +51,7 @@ Now comes the action, we want all news items to be copied into the
 `/news` folder:
 
   >>> browser.getControl('Add action').value = ['plone.actions.Copy']
-  >>> browser.getControl('Add', index=3).click()
+  >>> browser.getControl(name='form.button.AddAction').click()
   >>> ctrl = browser.getControl(name='form.widgets.target_folder')
   >>> from plone.uuid.interfaces import IUUID
   >>> ctrl.value = IUUID(portal.news)
@@ -69,7 +69,7 @@ A second rule will be added to notify users when a content is added.
   >>> browser.getControl('Save').click()
   >>> browser.open('http://nohost/plone/++rule++rule-2/@@manage-elements')
   >>> browser.getControl('Add action').value = ['plone.actions.Notify']
-  >>> browser.getControl('Add', index=3).click()
+  >>> browser.getControl(name='form.button.AddAction').click()
   >>> ctrl = browser.getControl(name='form.widgets.message')
   >>> ctrl.value = 'Content added'
   >>> browser.getControl('Save').click()

--- a/plone/app/contentrules/tests/multipublish.txt
+++ b/plone/app/contentrules/tests/multipublish.txt
@@ -33,13 +33,13 @@ condition for *published*:
   'http://nohost/plone/++rule++rule-1/@@manage-elements'
   >>> browser.getControl('Add condition').value = [
   ...     'plone.conditions.PortalType']
-  >>> browser.getControl('Add', index=1).click()
+  >>> browser.getControl(name='form.button.AddCondition').click()
   >>> browser.getControl('Content type').value = ['News Item']
   >>> browser.getControl('Save').click()
 
   >>> browser.getControl('Add condition').value = [
   ...     'plone.conditions.WorkflowState']
-  >>> browser.getControl('Add', index=1).click()
+  >>> browser.getControl(name='form.button.AddCondition').click()
   >>> browser.getControl('Workflow state').value = ['published']
   >>> browser.getControl('Save').click()
 
@@ -47,7 +47,7 @@ Now comes the action, we want all news items to be moved into the
 `/news` folder:
 
   >>> browser.getControl('Add action').value = ['plone.actions.Move']
-  >>> browser.getControl('Add', index=3).click()
+  >>> browser.getControl(name='form.button.AddAction').click()
   >>> ctrl = browser.getControl(name='form.widgets.target_folder')
   >>> from plone.uuid.interfaces import IUUID
   >>> ctrl.value = IUUID(portal.news)

--- a/plone/app/contentrules/tests/simplepublish.txt
+++ b/plone/app/contentrules/tests/simplepublish.txt
@@ -22,10 +22,10 @@ rule with a triggering event of `Workflow state changed`:
   >>> browser.getLink('Site Setup').click()
   >>> browser.getLink('Content Rules').click()
   >>> browser.getLink('Add content rule').click()
-  >>> browser.getControl('Title').value = 'Copy Published News'
-  >>> ctrl = browser.getControl('Triggering event')
+  >>> browser.getControl(name='form.widgets.title').value = 'Copy Published News'
+  >>> ctrl = browser.getControl(name='form.widgets.event:list')
   >>> ctrl.value = ['Workflow state changed']
-  >>> browser.getControl('Save').click()
+  >>> browser.getControl(name='form.buttons.save').click()
 
 We're back at the control panel.  Now we'll edit the content rule.
 We'll add a portal type condition for *news items* and a workflow state
@@ -33,14 +33,12 @@ condition for *published*:
 
   >>> browser.url
   'http://nohost/plone/++rule++rule-1/@@manage-elements'
-  >>> browser.getControl('Add condition').value = [
-  ...     'plone.conditions.PortalType']
+  >>> browser.getControl('Add condition').value = ['plone.conditions.PortalType']
   >>> browser.getControl('Add', index=1).click()
   >>> browser.getControl('Content type').value = ['News Item']
   >>> browser.getControl('Save').click()
 
-  >>> browser.getControl('Add condition').value = [
-  ...     'plone.conditions.WorkflowState']
+  >>> browser.getControl('Add condition').value = ['plone.conditions.WorkflowState']
   >>> browser.getControl('Add', index=1).click()
   >>> browser.getControl('Workflow state').value = ['published']
   >>> browser.getControl('Save').click()
@@ -49,11 +47,11 @@ Now comes the action, we want all news items to be copied into the
 `/news` folder:
 
   >>> browser.getControl('Add action').value = ['plone.actions.Copy']
-  >>> browser.getControl('Add', index=3).click()
+  >>> browser.getControl(name='form.button.AddAction').click()
   >>> ctrl = browser.getControl(name='form.widgets.target_folder')
   >>> from plone.uuid.interfaces import IUUID
   >>> ctrl.value = IUUID(portal.news)
-  >>> browser.getControl('Save').click()
+  >>> browser.getControl(name='form.buttons.save').click()
 
 We're done with setting up the content rule.  We need to now apply the
 rule to the root of the site before we try to add a news item:


### PR DESCRIPTION
- In browser tests, specify the buttons to be clicked by their name instead of their index.
- Fix import location for Products.ATContentTypes.interfaces.