### PR TITLE
Ensure error message is an unicode object and not utf-8 bytestring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Ensure error message is an unicode object
+  [mtrebron]
 
 
 4.0.13 (2016-12-30)

--- a/plone/app/contentrules/actions/workflow.py
+++ b/plone/app/contentrules/actions/workflow.py
@@ -71,7 +71,8 @@ class WorkflowActionExecutor(object):
     def error(self, obj, error):
         request = getattr(self.context, 'REQUEST', None)
         if request is not None:
-            title = utils.pretty_title_or_id(obj, obj)
+            title = utils.safe_unicode(utils.pretty_title_or_id(obj, obj))
+            error = utils.safe_unicode(error)
             message = _(
                 u"Unable to change state of ${name} as part of content rule 'workflow' action: ${error}",  # noqa
                 mapping={'name': title, 'error': error})


### PR DESCRIPTION
As requested here https://github.com/plone/plone.app.contentrules/issues/24