### PR TITLE
Fix issue where content rules edit form for a rules with assigned locations was broken because of move of getIcon

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+-  Fix issue where content rules edit forms were broken because of move of
+   getIcon from @@plone to @@plone_layout
+   [datakurre]
 
 
 4.0.13 (2016-12-30)

--- a/plone/app/contentrules/browser/elements.py
+++ b/plone/app/contentrules/browser/elements.py
@@ -153,7 +153,8 @@ class ManageElements(BrowserView):
         site = getToolByName(rule, "portal_url").getPortalObject()
         site_path = '/'.join(site.getPhysicalPath())
 
-        plone_view = getMultiAdapter((rule, self.request), name="plone")
+        plone_layout_view = getMultiAdapter((rule, self.request),
+                                            name="plone_layout")
 
         info = []
         if site_path in paths:
@@ -162,7 +163,7 @@ class ManageElements(BrowserView):
                 'url': site.absolute_url(),
                 'title': site.title_or_id(),
                 'description': site.Description(),
-                'icon': plone_view.getIcon(site)})
+                'icon': plone_layout_view.getIcon(site)})
 
         catalog = getToolByName(rule, "portal_catalog")
         for a in catalog(path=dict(query=list(paths), depth=0),
@@ -171,7 +172,7 @@ class ManageElements(BrowserView):
                 'url': a.getURL(),
                 'title': a.Title or a.getId,
                 'description': a.Description,
-                'icon': plone_view.getIcon(a)})
+                'icon': plone_layout_view.getIcon(a)})
 
         return info
 


### PR DESCRIPTION
Fixes #25 