### PR TITLE
Ensure error message is an unicode object and not utf-8 bytestring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Ensure error message is an unicode object
+  [mtrebron]
 
 
 4.0.14 (2017-04-02)

--- a/plone/app/contentrules/actions/workflow.py
+++ b/plone/app/contentrules/actions/workflow.py
@@ -71,7 +71,8 @@ class WorkflowActionExecutor(object):
     def error(self, obj, error):
         request = getattr(self.context, 'REQUEST', None)
         if request is not None:
-            title = utils.pretty_title_or_id(obj, obj)
+            title = utils.safe_unicode(utils.pretty_title_or_id(obj, obj))
+            error = utils.safe_unicode(error)
             message = _(
                 u"Unable to change state of ${name} as part of content rule 'workflow' action: ${error}",  # noqa
                 mapping={'name': title, 'error': error})


### PR DESCRIPTION
Basically is https://github.com/plone/plone.app.contentrules/pull/26 rebased on top of master and brought to plone org so that anyone can update and fix it.