### PR TITLE
Adapt tests to `Products.GenericSetup >= 2.0`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-4.0.19 (unreleased)
--------------------
+4.1 (unreleased)
+----------------
 
 Breaking changes:
 
-- *add item here*
+- Adapt tests to `Products.GenericSetup >= 2.0` thus requiring at least that
+  version.
 
 New features:
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,23 @@
 [buildout]
+extensions = mr.developer
+auto-checkout = *
 extends = https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
+          https://raw.githubusercontent.com/plone/buildout.coredev/5.2/versions.cfg
 package-name = plone.app.contentrules
 package-extras = [test]
+
+[remotes]
+plone = https://github.com/plone
+plone_push = git@github.com:plone
+zope = https://github.com/zopefoundation
+zope_push = git@github.com:zopefoundation
+
+[sources]
+Products.CMFCore = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git branch=master
+Products.CMFFormController = git ${remotes:plone}/Products.CMFFormController.git pushurl=${remotes:plone_push}/Products.CMFFormController.git branch=master
+Products.CMFPlone = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
+Products.GenericSetup = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master
+Products.PlonePAS = git ${remotes:plone}/Products.PlonePAS.git pushurl=${remotes:plone_push}/Products.PlonePAS.git branch=master
 
 [versions]
 plone.app.contentrules =

--- a/plone/app/contentrules/tests/test_configuration.py
+++ b/plone/app/contentrules/tests/test_configuration.py
@@ -119,7 +119,7 @@ class TestGenericSetup(ContentRulesTestCase):
         exporter = getMultiAdapter(
             (site, context), IBody, name=u'plone.contentrules')
 
-        expected = """<?xml version="1.0"?>
+        expected = """<?xml version="1.0" encoding="utf-8"?>
 <contentrules>
  <rule name="test1" title="Test rule 1" cascading="False"
     description="A test rule" enabled="True"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-version = '4.0.19.dev0'
+version = '4.1.dev0'
 
 setup(
     name='plone.app.contentrules',
@@ -55,7 +55,7 @@ setup(
         'Acquisition',
         'Products.CMFPlone',
         'Products.CMFCore',
-        'Products.GenericSetup',
+        'Products.GenericSetup >= 2.0.dev0',
         'Products.statusmessages',
         'ZODB3',
         'Zope2 >= 2.12.3',


### PR DESCRIPTION
This is needed to get Plone 5.2 coredev buildout green again. After the Python 3 changes of `Products.GenericSetup` have been merged to master.