### PR TITLE
Fix for Python3 tests

### DIFF
--- a/plone/app/contentrules/tests/test_action_mail.py
+++ b/plone/app/contentrules/tests/test_action_mail.py
@@ -199,7 +199,8 @@ class TestMailAction(ContentRulesTestCase):
         for msg in dummyMailHost.messages:
             if 'bar@foo.be' in msg:
                 mailSent1 = message_from_string(msg)
-            mailSent2 = message_from_string(msg)
+            else:
+                mailSent2 = message_from_string(msg)
         self.assertEqual('text/plain; charset="utf-8"',
                          mailSent1.get('Content-Type'))
         self.assertEqual('bar@foo.be', mailSent1.get('To'))


### PR DESCRIPTION
The test `plone.app.contentrules.tests.test_action_mail.TestMailAction.testExecuteMultiRecipients` is currently failing on jenkins: https://jenkins.plone.org/view/PLIPs/job/plip-py3/785/testReport/plone.app.contentrules.tests.test_action_mail/TestMailAction/testExecuteMultiRecipients/

This patch should fix it. Changelog already contains a relevant line.