### PR TITLE
Versioning action

### DIFF
--- a/news/44.feature
+++ b/news/44.feature
@@ -1,0 +1,2 @@
+Add new action `Version object`.
+[gbastien]

--- a/plone/app/contentrules/actions/configure.zcml
+++ b/plone/app/contentrules/actions/configure.zcml
@@ -206,4 +206,34 @@
          factory=".mail.MailAction"
          />
 
+    <!-- Versioning action -->
+
+    <adapter factory=".versioning.VersioningActionExecutor" />
+
+    <browser:page
+        for="plone.app.contentrules.browser.interfaces.IRuleActionAdding"
+        name="plone.actions.Versioning"
+        class=".versioning.VersioningAddFormView"
+        permission="plone.app.contentrules.ManageContentRules"
+      />
+
+    <browser:page
+        for="plone.app.contentrules.actions.versioning.IVersioningAction"
+        name="edit"
+        class=".versioning.VersioningEditFormView"
+        permission="plone.app.contentrules.ManageContentRules"
+      />
+
+    <plone:ruleAction
+        name="plone.actions.Versioning"
+        title="Versioning content"
+        description="Store a new version of the content"
+        for="*"
+        event="*"
+        addview="plone.actions.Versioning"
+        editview="edit"
+        schema=".versioning.IVersioningAction"
+        factory=".versioning.VersioningAction"
+        />
+
 </configure>

--- a/plone/app/contentrules/actions/configure.zcml
+++ b/plone/app/contentrules/actions/configure.zcml
@@ -226,8 +226,8 @@
 
     <plone:ruleAction
         name="plone.actions.Versioning"
-        title="Versioning content"
-        description="Store a new version of the content"
+        title="Version object"
+        description="Store a new version of the object"
         for="*"
         event="*"
         addview="plone.actions.Versioning"

--- a/plone/app/contentrules/actions/versioning.py
+++ b/plone/app/contentrules/actions/versioning.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+from OFS.SimpleItem import SimpleItem
+from plone.app.contentrules import PloneMessageFactory as _
+from plone.app.contentrules.actions import ActionAddForm
+from plone.app.contentrules.actions import ActionEditForm
+from plone.app.contentrules.browser.formhelper import ContentRuleFormWrapper
+from plone.contentrules.rule.interfaces import IExecutable
+from plone.contentrules.rule.interfaces import IRuleElementData
+from Products.CMFCore.utils import getToolByName
+from zope import schema
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+class IVersioningAction(Interface):
+    """Interface for the configurable aspects of a versioning action.
+
+    This is also used to create add and edit forms, below.
+    """
+
+    comment = schema.TextLine(
+        title=_(u'Comment'),
+        description=_(
+            u'The comment added to the history while versioning the content.'),
+        required=False,
+    )
+
+
+@implementer(IVersioningAction, IRuleElementData)
+class VersioningAction(SimpleItem):
+    """The actual persistent implementation of the versioning action element.
+    """
+
+    comment = ''
+
+    element = 'plone.actions.Versioning'
+
+    @property
+    def summary(self):
+        return _(
+            u'Versioning with comment ${comment}',
+            mapping=dict(comment=self.comment),
+        )
+
+
+@adapter(Interface, IVersioningAction, Interface)
+@implementer(IExecutable)
+class VersioningActionExecutor(object):
+    """The executor for this action.
+
+    This is registered as an adapter in configure.zcml
+    """
+
+    def __init__(self, context, element, event):
+        self.context = context
+        self.element = element
+        self.event = event
+
+    def __call__(self):
+        comment = _(self.element.comment)
+        pr = getToolByName(self.context, 'portal_repository')
+        pr.save(obj=self.event.object, comment=comment)
+        return True
+
+
+class VersioningAddForm(ActionAddForm):
+    """An add form for versioning rule actions.
+    """
+    schema = IVersioningAction
+    label = _(u'Add Versioning Action')
+    description = _(u'A versioning action will store a version of a content '
+                    u'no matter versioning is enabled for it or not.')
+    form_name = _(u'Configure element')
+    Type = VersioningAction
+
+
+class VersioningAddFormView(ContentRuleFormWrapper):
+    form = VersioningAddForm
+
+
+class VersioningEditForm(ActionEditForm):
+    """An edit form for versioning rule actions.
+
+    z3c.form does all the magic here.
+    """
+    schema = IVersioningAction
+    label = _(u'Edit Versioning Action')
+    description = _(u'A versioning action will store a version of a content '
+                    u'no matter versioning is enabled for it or not.')
+    form_name = _(u'Configure element')
+
+
+class VersioningEditFormView(ContentRuleFormWrapper):
+    form = VersioningEditForm

--- a/plone/app/contentrules/tests/test_action_versioning.py
+++ b/plone/app/contentrules/tests/test_action_versioning.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from plone.app.contentrules.actions.versioning import VersioningAction
+from plone.app.contentrules.actions.versioning import VersioningEditFormView
+from plone.app.contentrules.rule import Rule
+from plone.app.contentrules.tests.base import ContentRulesTestCase
+from plone.contentrules.engine.interfaces import IRuleStorage
+from plone.contentrules.rule.interfaces import IExecutable
+from plone.contentrules.rule.interfaces import IRuleAction
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(Interface)
+class DummyEvent(object):
+
+    def __init__(self, object):
+        self.object = object
+
+
+class TestVersioningAction(ContentRulesTestCase):
+
+    def testRegistered(self):
+        element = getUtility(IRuleAction, name='plone.actions.Versioning')
+        self.assertEqual('plone.actions.Versioning', element.addview)
+        self.assertEqual('edit', element.editview)
+        self.assertEqual(None, element.for_)
+        self.assertEqual(None, element.event)
+
+    def testInvokeAddView(self):
+        element = getUtility(IRuleAction, name='plone.actions.Versioning')
+        storage = getUtility(IRuleStorage)
+        storage[u'foo'] = Rule()
+        rule = self.portal.restrictedTraverse('++rule++foo')
+
+        adding = getMultiAdapter((rule, self.request), name='+action')
+        addview = getMultiAdapter((adding, self.request), name=element.addview)
+
+        addview.form_instance.update()
+        content = addview.form_instance.create(data={'comment': 'Hello world'})
+        addview.form_instance.add(content)
+
+        e = rule.actions[0]
+        self.assertTrue(isinstance(e, VersioningAction))
+        self.assertEqual('Hello world', e.comment)
+
+    def testInvokeEditView(self):
+        element = getUtility(IRuleAction, name='plone.actions.Versioning')
+        e = VersioningAction()
+        editview = getMultiAdapter((e, self.request), name=element.editview)
+        self.assertTrue(isinstance(editview, VersioningEditFormView))
+
+    def testExecute(self):
+        e = VersioningAction()
+        e.comment = 'Hello world'
+
+        ex = getMultiAdapter((self.folder, e, DummyEvent(self.folder)), IExecutable)
+        # not version for now
+        pr = self.portal.portal_repository
+        self.assertEqual(pr.getHistoryMetadata(self.folder), [])
+
+        # action will create first version
+        self.assertEqual(True, ex())
+        self.assertEqual(pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 1)
+        # calling action again will create a second version
+        ex()
+        self.assertEqual(pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 2)

--- a/plone/app/contentrules/tests/test_action_versioning.py
+++ b/plone/app/contentrules/tests/test_action_versioning.py
@@ -55,14 +55,17 @@ class TestVersioningAction(ContentRulesTestCase):
         e = VersioningAction()
         e.comment = 'Hello world'
 
-        ex = getMultiAdapter((self.folder, e, DummyEvent(self.folder)), IExecutable)
+        ex = getMultiAdapter(
+            (self.folder, e, DummyEvent(self.folder)), IExecutable)
         # not version for now
         pr = self.portal.portal_repository
         self.assertEqual(pr.getHistoryMetadata(self.folder), [])
 
         # action will create first version
         self.assertEqual(True, ex())
-        self.assertEqual(pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 1)
+        self.assertEqual(
+            pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 1)
         # calling action again will create a second version
         ex()
-        self.assertEqual(pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 2)
+        self.assertEqual(
+            pr.getHistoryMetadata(self.folder).getLength(countPurged=False), 2)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     namespace_packages=['plone', 'plone.app'],
     include_package_data=True,
     zip_safe=False,
-    extras_require={'test': 'plone.app.testing'},
+    extras_require={'test': ['plone.app.testing', 'plone.app.contenttypes[test]']},
     install_requires=[
         'setuptools',
         'six',


### PR DESCRIPTION
This adds a "Version object" action that will store a new version of the object.

I think this should be part of the core contentrules package.

To be able to run tests in the plone.app.contentrules buildout, I had to adapt setup.py to add 'plone.app.contenttypes[test]' to the 'test' extras_require, this is because the plone.app.conenttypes fixture depends of the plone.app.event fixture that uses robotframework.

Please review/comment/merge, this is related to #44 

If merged to the master, I will also do a PR for 4.0.x so it works on Plone 5.1.x

Thank you,

Gauthier