### PR TITLE
Fixed deprecation warning for ComponentLookupError.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for ComponentLookupError.
+[maurits]

--- a/plone/app/contentrules/actions/mail.py
+++ b/plone/app/contentrules/actions/mail.py
@@ -18,7 +18,7 @@ from smtplib import SMTPException
 from zope import schema
 from zope.component import adapter
 from zope.component import getUtility
-from zope.component.interfaces import ComponentLookupError
+from zope.interface.interfaces import ComponentLookupError
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface import Interface


### PR DESCRIPTION
```
DeprecationWarning: ComponentLookupError is deprecated.
Import from zope.interface.interfaces
```