### PR TITLE
Backport "fix genericsetup export with complex properties" to 4.0

### DIFF
--- a/news/50.bugfix
+++ b/news/50.bugfix
@@ -1,0 +1,1 @@
+fix genericsetup export of properties of rules that have more complex fields such as IDict.

--- a/plone/app/contentrules/exportimport/rules.py
+++ b/plone/app/contentrules/exportimport/rules.py
@@ -84,6 +84,7 @@ class PropertyRuleElementExportImportHandler(object):
             return
 
         field = field.bind(self.element)
+        # child is minidom but supermodel needs an etree node so we need to convert it
         child = etree.fromstring(child.toxml())
 
         value = elementToValue(field, child)
@@ -100,7 +101,8 @@ class PropertyRuleElementExportImportHandler(object):
 
         child = doc.createElement('property')
         child.setAttribute('name', field.__name__)
-        
+
+        # supermodel gives us an etree node but GS uses minidom so we need to convert it
         node = valueToElement(field, value)
         if node.text:
             child.appendChild(doc.createTextNode(six.text_type(node.text)))

--- a/plone/app/contentrules/exportimport/rules.py
+++ b/plone/app/contentrules/exportimport/rules.py
@@ -26,6 +26,9 @@ from zope.interface import Interface
 from zope.schema.interfaces import ICollection
 from zope.schema.interfaces import IField
 from zope.schema.interfaces import IFromUnicode
+from plone.supermodel.utils import elementToValue, valueToElement
+from lxml import etree
+from xml.dom import minidom
 
 
 import six
@@ -81,25 +84,9 @@ class PropertyRuleElementExportImportHandler(object):
             return
 
         field = field.bind(self.element)
-        value = None
+        child = etree.fromstring(child.toxml())
 
-        # If we have a collection, we need to look at the value_type.
-        # We look for <element>value</element> child nodes and get the
-        # value from there
-        if ICollection.providedBy(field):
-            value_type = field.value_type
-            value = []
-            for element in child.childNodes:
-                if element.nodeName != 'element':
-                    continue
-                element_value = self.extract_text(element)
-                value.append(self.from_unicode(value_type, element_value))
-            value = self.field_typecast(field, value)
-
-        # Otherwise, just get the value of the <property /> node
-        else:
-            value = self.extract_text(child)
-            value = self.from_unicode(field, value)
+        value = elementToValue(field, child)
 
         field.validate(value)
         field.set(self.element, value)
@@ -113,53 +100,15 @@ class PropertyRuleElementExportImportHandler(object):
 
         child = doc.createElement('property')
         child.setAttribute('name', field.__name__)
-
-        if value is not None:
-            if ICollection.providedBy(field):
-                for e in value:
-                    list_element = doc.createElement('element')
-                    list_element.appendChild(doc.createTextNode(str(e)))
-                    child.appendChild(list_element)
-            else:
-                child.appendChild(doc.createTextNode(six.text_type(value)))
-
+        
+        node = valueToElement(field, value)
+        if node.text:
+            child.appendChild(doc.createTextNode(six.text_type(node.text)))
+        # Assumes there are not other text nodes and we can throw away the parent node    
+        for node in node.iterchildren():
+            xml = etree.tostring(node).decode()
+            child.appendChild(minidom.parseString(xml).firstChild)
         return child
-
-    def extract_text(self, node):
-        node.normalize()
-        text = u''
-        for child in node.childNodes:
-            if child.nodeType == node.TEXT_NODE:
-                text += child.nodeValue
-        return text
-
-    def from_unicode(self, field, value):
-
-        # XXX: Bool incorrectly omits to declare that it implements
-        # IFromUnicode, even though it does.
-        import zope.schema
-        if (
-            IFromUnicode.providedBy(field) or
-            isinstance(field, zope.schema.Bool)
-        ):
-            return field.fromUnicode(value)
-        else:
-            return self.field_typecast(field, value)
-
-    def field_typecast(self, field, value):
-        # A slight hack to force sequence types to the right type
-        typecast = getattr(field, '_type', None)
-        if typecast is not None:
-            if not isinstance(typecast, (list, tuple)):
-                typecast = (typecast, )
-            for tc in reversed(typecast):
-                if callable(tc):
-                    try:
-                        value = tc(value)
-                        break
-                    except Exception:
-                        pass
-        return value
 
 
 @adapter(ISiteRoot, ISetupEnviron)

--- a/plone/app/contentrules/exportimport/rules.py
+++ b/plone/app/contentrules/exportimport/rules.py
@@ -365,5 +365,9 @@ def exportRules(context):
     if exporter is not None:
         filename = '{0}{1}'.format(exporter.name, exporter.suffix)
         body = exporter.body
+        # make sure it's encoded as earlier version of GS didn't do this
+        if isinstance(body, six.text_type):
+            encoding = context.getEncoding() or 'utf-8'
+            body = body.encode(encoding)
         if body is not None:
             context.writeDataFile(filename, body, exporter.mime_type)

--- a/plone/app/contentrules/exportimport/rules.py
+++ b/plone/app/contentrules/exportimport/rules.py
@@ -106,7 +106,7 @@ class PropertyRuleElementExportImportHandler(object):
             child.appendChild(doc.createTextNode(six.text_type(node.text)))
         # Assumes there are not other text nodes and we can throw away the parent node    
         for node in node.iterchildren():
-            xml = etree.tostring(node).decode()
+            xml = etree.tostring(node, encoding="utf8")
             child.appendChild(minidom.parseString(xml).firstChild)
         return child
 

--- a/plone/app/contentrules/tests/profiles/testing/contentrules.xml
+++ b/plone/app/contentrules/tests/profiles/testing/contentrules.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <contentrules>
 
     <rule

--- a/plone/app/contentrules/tests/test_configuration.py
+++ b/plone/app/contentrules/tests/test_configuration.py
@@ -119,7 +119,19 @@ class TestGenericSetup(ContentRulesTestCase):
         exporter = getMultiAdapter(
             (site, context), IBody, name=u'plone.contentrules')
 
-        expected = """<?xml version="1.0"?>
+        body = exporter.body.decode('utf8')
+
+        # There is a bug in supermodel such that Set fields can be exported in a random order
+        body = body.replace("""
+     <element>News Item</element>
+     <element>Document</element>
+""","""
+     <element>Document</element>
+     <element>News Item</element>
+"""
+        )
+
+        expected = u"""<?xml version="1.0" encoding="utf-8"?>
 <contentrules>
  <rule name="test1" title="Test rule 1" cascading="False"
     description="A test rule" enabled="True"
@@ -128,8 +140,8 @@ class TestGenericSetup(ContentRulesTestCase):
   <conditions>
    <condition type="plone.conditions.PortalType">
     <property name="check_types">
-     <element>News Item</element>
      <element>Document</element>
+     <element>News Item</element>
     </property>
    </condition>
    <condition type="plone.conditions.Role">
@@ -216,5 +228,4 @@ class TestGenericSetup(ContentRulesTestCase):
 </contentrules>
 """
 
-        body = exporter.body
-        self.assertEqual(expected.strip(), body.strip(), body)
+        self.assertEqual(expected.strip(), body.strip())

--- a/plone/app/contentrules/tests/test_configuration.py
+++ b/plone/app/contentrules/tests/test_configuration.py
@@ -227,5 +227,4 @@ class TestGenericSetup(ContentRulesTestCase):
  <assignment name="test5" bubbles="False" enabled="False" location=""/>
 </contentrules>
 """
-
         self.assertEqual(expected.strip(), body.strip())

--- a/plone/app/contentrules/tests/test_configuration.py
+++ b/plone/app/contentrules/tests/test_configuration.py
@@ -128,8 +128,8 @@ class TestGenericSetup(ContentRulesTestCase):
   <conditions>
    <condition type="plone.conditions.PortalType">
     <property name="check_types">
-     <element>Document</element>
      <element>News Item</element>
+     <element>Document</element>
     </property>
    </condition>
    <condition type="plone.conditions.Role">


### PR DESCRIPTION
[PR #51](https://github.com/plone/plone.app.contentrules/pull/51) fixed some issues with exporting complex properties (such as IDicts). This PR is a backport of those fixes to 4.0.x. for use in Plone 5 versions prior to 5.2.