### PR TITLE
Update plone.app.contentrules templates to Bootstrap 4

### DIFF
--- a/plone/app/contentrules/browser/templates/controlpanel.pt
+++ b/plone/app/contentrules/browser/templates/controlpanel.pt
@@ -8,16 +8,17 @@
 
 <body>
 
-<div metal:fill-slot="prefs_configlet_main"
+<metal:main metal:fill-slot="prefs_configlet_main"
      tal:define="rules view/registeredRules">
 
-    <script type="text/javascript" src="++resource++manage-contentrules.js"
-        tal:attributes="src string:${context/portal_url}/++resource++manage-contentrules.js">
-    </script>
-    <link rel="stylesheet" type="text/css" media="all"
-          href="++resource++manage-contentrules.css"
-          tal:attributes="href string:${context/portal_url}/++resource++manage-contentrules.css" />
+  <script type="text/javascript" src="++resource++manage-contentrules.js"
+      tal:attributes="src string:${context/portal_url}/++resource++manage-contentrules.js">
+  </script>
+  <link rel="stylesheet" type="text/css" media="all"
+        href="++resource++manage-contentrules.css"
+        tal:attributes="href string:${context/portal_url}/++resource++manage-contentrules.css" />
 
+  <header>
     <h1 class="documentFirstHeading"
         i18n:translate="title_manage_contentrules">Content Rules</h1>
 
@@ -27,7 +28,9 @@
         take place. After defining rules, you may want to go to a folder
         to assign them, using the "rules" item in the actions menu.
     </p>
+  </header>
 
+  <div id="content-core">
     <div id="translated-text" style="display:none">
       <span id="trns_form_error" i18n:translate="">
         There was an error saving content rules.
@@ -78,34 +81,38 @@
                 <span i18n:translate="">Filter:</span>
                 <span class="filter-option"
                       tal:repeat="rule view/ruleTypesToShow">
-                    <input id="all" type="checkbox"
-                           tal:attributes="id rule/id"
-                           />
-                    <label
-                           for="all"
-                           tal:attributes="for rule/id"
-                           tal:content="rule/title">
-                           All</label>
+                    <div class="form-check form-check-inline">
+                      <input id="all" class="form-check-input" type="checkbox"
+                             tal:attributes="id rule/id"
+                             />
+                      <label class="form-check-label"
+                             for="all"
+                             tal:attributes="for rule/id"
+                             tal:content="rule/title">
+                             All</label>
+                    </div>
                 </span>
               </span>
               <span class="state-filters" tal:condition="rules">
                 <span class="filter-option"
                       tal:repeat="state view/statesToShow">
-                    <input id="all" type="checkbox"
-                           tal:attributes="id state/id"
-                           />
-                    <label
-                           for="all"
-                           tal:attributes="for state/id"
-                           tal:content="state/title">
-                           All</label>
+                    <div class="form-check form-check-inline">
+                      <input id="all" class="form-check-input" type="checkbox"
+                             tal:attributes="id state/id"
+                             />
+                      <label class="form-check-label"
+                             for="all"
+                             tal:attributes="for state/id"
+                             tal:content="state/title">
+                             All</label>
+                    </div>
                 </span>
               </span>
             </div>
             <div class="visualClear"><!-- --></div>
             <div id="rules_table_form"
                  metal:define-macro="rules_table_form">
-            <table  class="listing nosort controlpanel-listing"
+            <table  class="listing nosort controlpanel-listing table"
                     tal:condition="rules">
                 <thead>
                     <tr>
@@ -136,22 +143,20 @@
                                   i18n:translate="">trigger</span>
                         </td>
                         <td class="checker">
-                            <img
-                                 class="icon-contentrule-enabled-assigned"
-                                 src="confirm_icon.png"
-                                 alt="enabled"
-                                 width="16"
-                                 height="16"
-                                 i18n:attributes="alt label_contentrules_rule_enabled;" />
-                            <img
-                                 class="icon-contentrule-enabled-unassigned"
-                                 src="error_icon.png"
-                                 alt="unassigned"
-                                 title="this rule has not been assigned"
-                                 width="16"
-                                 height="16"
-                                 i18n:attributes="alt label_contentrules_rule_unassigned;
-                                                  title title_contentrule_rule_unassigned;" />
+                            <span 
+                                class="badge badge-primary icon-contentrule-enabled-assigned" 
+                                alt="enabled"
+                                i18n:attributes="alt label_contentrules_rule_enabled;">
+                                  <i class="glyphicon glyphicon-ok"></i>
+                            </span>
+
+                            <span 
+                                class="badge badge-danger icon-contentrule-enabled-unassigned" 
+                                alt="unassigned"
+                                i18n:attributes="alt label_contentrules_rule_unassigned;
+                                                 title title_contentrule_rule_unassigned;">
+                                  <i class="glyphicon glyphicon-warning-sign"></i>
+                            </span>
                         </td>
                         <td>
                         <form style="display: inline" method="POST"
@@ -160,21 +165,24 @@
                         <input type="hidden"
                                name="rule-id"
                                tal:attributes="value rule/id">
-                        <input class="context btn-rule-action btn-rule-enable" type="submit" value="Enable"
+                        <button class="context btn-rule-action btn-rule-enable btn btn-primary" type="submit" value="Enable"
                                name="form.button.EnableRule"
                                tal:attributes="data-value rule/id;
                                                data-url string:$portal_url/@@contentrule-enable"
-                               i18n:attributes="value label_enable;" />
-                        <input class="standalone btn-rule-action btn-rule-disable" type="submit" value="Disable"
+                               i18n:translate=""
+                               i18n:attributes="value label_enable;">Enable</button>
+                        <button class="standalone btn-rule-action btn-rule-disable btn btn-secondary" type="submit" value="Disable"
                                name="form.button.DisableRule"
                                tal:attributes="data-value rule/id;
                                                data-url string:$portal_url/@@contentrule-disable"
-                               i18n:attributes="value label_disable;" />
-                        <input class="destructive btn-rule-action btn-rule-delete" type="submit" value="Delete"
+                               i18n:translate=""
+                               i18n:attributes="value label_disable;">Disable</button>
+                        <button class="destructive btn-rule-action btn-rule-delete btn btn-danger" type="submit" value="Delete"
                                tal:attributes="data-value rule/id;
                                                data-url string:$portal_url/@@contentrule-delete"
                                name="form.button.DeleteRule"
-                               i18n:attributes="value label_delete;" />
+                               i18n:translate=""
+                               i18n:attributes="value label_delete;">Delete</button>
                          </form>
                         </td>
                     </tr>
@@ -183,10 +191,11 @@
             </table>
             </div>
             <a id="#addcontentrule" tal:attributes="href add_url"
-               class="plone-btn plone-btn-primary"
+               class="plone-btn plone-btn-primary btn btn-primary"
                i18n:translate="label_contentrule_add">Add content rule</a>
        </fieldset>
-</div>
+  </div>
+</metal:main>
 </body>
 </html>
 

--- a/plone/app/contentrules/browser/templates/controlpanel.pt
+++ b/plone/app/contentrules/browser/templates/controlpanel.pt
@@ -155,7 +155,7 @@
                                 alt="unassigned"
                                 i18n:attributes="alt label_contentrules_rule_unassigned;
                                                  title title_contentrule_rule_unassigned;">
-                                  <i class="glyphicon glyphicon-warning-sign"></i>
+                                  <i class="glyphicon glyphicon-remove"></i>
                             </span>
                         </td>
                         <td>

--- a/plone/app/contentrules/browser/templates/manage-assignments.pt
+++ b/plone/app/contentrules/browser/templates/manage-assignments.pt
@@ -102,31 +102,32 @@
                     </table>
                 </div>
 
-                <form class="formControls" tal:define="assignable_rules view/assignable_rules" tal:condition="assignable_rules"
+                <form class="formControls form-group" tal:define="assignable_rules view/assignable_rules" tal:condition="assignable_rules"
                       tal:attributes="action string:${view/view_url}" method="post">
                     <div class="field chooser-right">
                         <label for="" i18n:translate="contentrules_add_assignment">
                             Assign rule here
                         </label>
                         <div>
-                          <select name="rule_id" size="1" id="select-rules">
+                          <select class="form-control" name="rule_id" size="1" id="select-rules">
                               <tal:options repeat="rule assignable_rules">
                                   <option tal:attributes="value rule/id"
                                           tal:content="rule/title">Addable rule name</option>
                               </tal:options>
                           </select>
-                          <input class="context"
+                          <button class="context btn btn-primary"
                                  type="submit"
                                  name="form.button.AddAssignment"
                                  value="Add"
-                                 i18n:attributes="value label_add;" />
+                                 i18n:attributes="value label_add;"
+                                 i18n:translate="label_add">Add</button>
                         </div>
                     </div>
                 </form>
 
                 <div class="visualClear"><!-- --></div>
 
-                <form tal:attributes="action view/view_url" method="post"
+                <form class="form-group" tal:attributes="action view/view_url" method="post"
                       tal:define="assigned_rules view/assigned_rules" tal:condition="assigned_rules">
                     <table class="listing nosort">
                         <thead>
@@ -216,31 +217,36 @@
                     </table>
 
                     <div class="formControls">
-                        <input name="form.button.Enable"
-                               class="context"
+                        <button name="form.button.Enable"
+                               class="context btn btn-primary"
                                type="submit"
                                value="Enable"
-                               i18n:attributes="value label_enable;" />
-                        <input name="form.button.Disable"
-                               class="standalone"
+                               i18n:attributes="value label_enable;"
+                               i18n:translate="label_enable">Enable</button>
+                        <button name="form.button.Disable"
+                               class="standalone btn btn-primary"
                                type="submit"
                                value="Disable"
-                               i18n:attributes="value label_disable;" />
-                        <input name="form.button.Bubble"
-                               class="standalone"
+                               i18n:attributes="value label_disable;"
+                               i18n:translate="label_disable">Disable</button>
+                        <button name="form.button.Bubble"
+                               class="standalone btn btn-primary"
                                type="submit"
                                value="Apply to subfolders"
-                               i18n:attributes="value label_apply_to_subfolders;" />
-                        <input name="form.button.NoBubble"
-                               class="standalone"
+                               i18n:attributes="value label_apply_to_subfolders;"
+                               i18n:translate="label_apply_to_subfolders">Apply to subfolders</button>
+                        <button name="form.button.NoBubble"
+                               class="standalone btn btn-primary"
                                type="submit"
                                value="Disable apply to subfolders"
-                               i18n:attributes="value label_disable_apply_to_subfolders;" />
-                        <input name="form.button.Delete"
-                               class="destructive"
+                               i18n:attributes="value label_disable_apply_to_subfolders;"
+                               i18n:translate="label_disable_apply_to_subfolders">Disable apply to subfolders</button>
+                        <button name="form.button.Delete"
+                               class="destructive btn btn-danger"
                                type="submit"
                                value="Unassign"
-                               i18n:attributes="value label_unassign;" />
+                               i18n:attributes="value label_unassign;"
+                               i18n:translate="label_unassign">Unassign</button>
                     </div>
                 </form>
             </div>

--- a/plone/app/contentrules/browser/templates/manage-elements.pt
+++ b/plone/app/contentrules/browser/templates/manage-elements.pt
@@ -47,7 +47,7 @@
           There is not any additional condition checked on this rule.
           </span>
         </div>
-        <form tal:attributes="action view/view_url" method="post"
+        <form class="form-group" tal:attributes="action view/view_url" method="post"
               tal:define="auth_token context/@@authenticator/token"
               tal:repeat="condition conditions">
             <span tal:replace="structure context/@@authenticator/authenticator"></span>
@@ -56,26 +56,27 @@
             <div class="rule-element">
                 <div class="rule-operations">
                     <a tal:attributes="href string:${condition/editview}?_authenticator=${auth_token}"
-                       class="pat-plone-modal plone-btn plone-btn-primary"
+                       class="pat-plone-modal plone-btn-primary btn btn-primary"
                        tal:condition="condition/editview" i18n:translate="label_edit">Edit</a>
-                    <input type="submit"
+                    <button type="submit"
                            name="form.button.DeleteCondition"
                            value="Remove"
-                           class="context"
+                           class="context btn btn-danger"
                            i18n:attributes="value label_remove;"
-                           />
-                    <input tal:attributes="disabled python:condition['first'] and 'disabled' or None"
+                           i18n:translate="label_remove"
+                           >Remove</button>
+                    <button tal:attributes="disabled python:condition['first'] and 'disabled' or None"
                            type="submit"
                            name="form.button.MoveConditionUp"
                            value="&uarr;"
-                           class="context"
-                           />
-                    <input tal:attributes="disabled python:condition['last'] and 'disabled' or None"
+                           class="context btn btn-primary"
+                           >&uarr;</button>
+                    <button tal:attributes="disabled python:condition['last'] and 'disabled' or None"
                            type="submit"
                            name="form.button.MoveConditionDown"
                            value="&darr;"
-                           class="context"
-                           />
+                           class="context btn btn-primary"
+                           >&darr;</button>
                 </div>
                 <div class="portalMessage warning">
                     <strong tal:content="condition/title" i18n:translate="">Transition was publish.</strong>
@@ -86,7 +87,7 @@
             </div>
         </form>
 
-        <form tal:attributes="action string:${view/base_url}/+condition" method="get"
+        <form class="form-group" tal:attributes="action string:${view/base_url}/+condition" method="get"
             id="add-condition">
             <span tal:replace="structure context/@@authenticator/authenticator"></span>
             <div class="chooser-right">
@@ -95,18 +96,19 @@
                     Add condition
                 </label>
 
-                <select name=":action" size="1" id="contentrules-add-condition">
+                <select name=":action" size="1" id="contentrules-add-condition" class="form-control">
                     <tal:block repeat="condition view/addable_conditions">
                         <option tal:attributes="value condition/addview"
                                 i18n:translate=""
                                 tal:content="condition/title" />
                     </tal:block>
                 </select>
-                <input class="context allowMultiSubmit"
+                <button class="context allowMultiSubmit btn btn-primary"
                        type="submit"
                        name="form.button.AddCondition"
                        value="Add"
-                       i18n:attributes="value label_add;" />
+                       i18n:attributes="value label_add;"
+                       i18n:translate="label_add">Add</button>
             </div>
             &nbsp; <!-- For Safari -->
         </form>
@@ -124,7 +126,7 @@
           Click on Add button to setup an action.
           </span>
         </div>
-        <form tal:attributes="action view/view_url" method="post"
+        <form class="form-group" tal:attributes="action view/view_url" method="post"
               tal:define="auth_token context/@@authenticator/token"
               tal:repeat="action actions">
             <span tal:replace="structure context/@@authenticator/authenticator"></span>
@@ -134,31 +136,33 @@
                 <div class="rule-operations">
                     <a tal:attributes="href string:${action/editview}?_authenticator=${auth_token}" class="pat-plone-modal"
                        tal:condition="action/editview">
-                      <input type="submit"
+                      <button type="submit"
                              name="form.button.EditAction"
                              value="Edit"
-                             class="context"
+                             class="context btn btn-primary"
                              i18n:attributes="value label_edit;"
-                             />
+                             i18n:translate="label_edit;"
+                             >Edit</button>
                     </a>
-                    <input type="submit"
+                    <button type="submit"
                            name="form.button.DeleteAction"
                            value="Remove"
-                           class="context"
+                           class="context btn btn-danger"
                            i18n:attributes="value label_remove;"
-                           />
-                    <input tal:attributes="disabled python:action['first'] and 'disabled' or None"
+                           i18n:translate="label_remove"
+                           >Remove</button>
+                    <button tal:attributes="disabled python:action['first'] and 'disabled' or None"
                            type="submit"
                            name="form.button.MoveActionUp"
                            value="&uarr;"
-                           class="context"
-                           />
-                    <input tal:attributes="disabled python:action['last'] and 'disabled' or None"
+                           class="context btn btn-primary"
+                           >&uarr;</button>
+                    <button tal:attributes="disabled python:action['last'] and 'disabled' or None"
                            type="submit"
                            name="form.button.MoveActionDown"
                            value="&darr;"
-                           class="context"
-                           />
+                           class="context btn btn-primary"
+                           >&darr;</button>
                 </div>
                 <div class="portalMessage warning">
                     <strong tal:content="action/title"
@@ -170,24 +174,25 @@
             </div>
         </form>
 
-        <form tal:attributes="action string:${view/base_url}/+action" method="get"
+        <form class="form-group" tal:attributes="action string:${view/base_url}/+action" method="get"
           id="add-action">
             <span tal:replace="structure context/@@authenticator/authenticator"></span>
             <div class="chooser-right">
                 <label i18n:translate="contentrules_add_action"
                        for="contentrules-add-action">Add action</label>
-                <select name=":action" size="1" id="contentrules-add-action">
+                <select name=":action" size="1" id="contentrules-add-action" class="form-control">
                     <tal:block repeat="action view/addable_actions">
                         <option tal:attributes="value action/addview"
                                 i18n:translate=""
                                 tal:content="action/title"></option>
                     </tal:block>
                 </select>
-                <input class="context allowMultiSubmit"
+                <button class="context allowMultiSubmit btn btn-primary"
                        type="submit"
                        name="form.button.AddAction"
                        value="Add"
-                       i18n:attributes="value label_add;" />
+                       i18n:attributes="value label_add;"
+                       i18n:translate="label_add">Add</button>
             </div>
             &nbsp; <!-- For Safari -->
         </form>
@@ -211,7 +216,7 @@
                 click on 'rule' tab, and then locally setup the rules.
               </span>
 
-              <form  tal:attributes="action view/view_url" method="post">
+              <form class="form-group" tal:attributes="action view/view_url" method="post">
                 <span tal:replace="structure context/@@authenticator/authenticator"/>
                 <label i18n:translate="contentrules_assignments_shortcuts">Shortcuts:</label>
                 <input type="submit" class="context"
@@ -245,14 +250,14 @@
 
     <fieldset id="configure-rule">
         <legend i18n:translate="">Configure rule</legend>
-        <form tal:attributes="action view/view_url" method="post">
+        <form class="form-group" tal:attributes="action view/view_url" method="post">
             <span tal:replace="structure context/@@authenticator/authenticator"></span>
             <div class="field">
                 <label for="form.title" i18n:translate="label_title">Title</label>
                 <div class="formHelp" i18n:translate="description_contentrule_title">
                     Please set a descriptive title for the rule.
                 </div>
-                <input id="form.title" type="text" width="50" name="title"
+                <input id="form.title" class="form-control" type="text" width="50" name="title"
                     tal:attributes="value request/ruleTitle | view/rule_title"/>
             </div>
             <div class="field">
@@ -260,7 +265,7 @@
                 <div class="formHelp" i18n:translate="contentrules_description_description">
                     Enter a short description of the rule and its purpose.
                 </div>
-                <textarea id="form.description"  name="description"
+                <textarea id="form.description" class="form-control" name="description"
                           tal:content="request/ruleDescription | view/rule_description ">
                 </textarea>
             </div>
@@ -299,11 +304,12 @@
             </div>
 
             <div class="formControls">
-                <input class="context"
+                <button class="context btn btn-primary"
                        type="submit"
                        name="form.button.Save"
                        value="Save"
-                       i18n:attributes="value label_save;" />
+                       i18n:attributes="value label_save;"
+                       i18n:translate="label_save">Save</button>
             </div>
         </form>
     </fieldset>


### PR DESCRIPTION
Following the guidelines in plone/Products.CMFPlone#2967 and https://github.com/plone/plone.app.contentrules/issues/53 I've updated the following templates from plone.app.contentrules:
- plone.app.contentrules.browser.templates.controlpanel.pt
- plone.app.contentrules.browser.templates.manage-elements.pt
- plone.app.contentrules.browser.templates.manage-assignments.pt

Decisions
- 'btn-danger' for form.button.DeleteRule
- 'btn-secondary' for form.button.DisableRule
- 'btn-primary' for form.button.EnableRule
- Use default Bootstrap 4 "table" class
- Use form check inline for filters
- Follows structure article#content > header + #content-crore
- Fix the broken "enabled" and "unassigned" icon and use an icon from Bootstrap instead;
- Update each form, select and inputs with Bootstrap markup 'form-group' and 'form-controls'

