### PR TITLE
Explicitly mark exclude_actor as not-required

### DIFF
--- a/news/77.bugfix
+++ b/news/77.bugfix
@@ -1,0 +1,2 @@
+Explicitly mark exclude_actor as not-required
+[erral]

--- a/plone/app/contentrules/actions/mail.py
+++ b/plone/app/contentrules/actions/mail.py
@@ -53,6 +53,7 @@ class IMailAction(Interface):
     exclude_actor = schema.Bool(
         title=_("Exclude actor from recipients"),
         description=_("Do not send the email to the user that did the action."),
+        required=False,
     )
     message = schema.Text(
         title=_("Message"),

--- a/plone/app/contentrules/actions/mail.py
+++ b/plone/app/contentrules/actions/mail.py
@@ -53,7 +53,6 @@ class IMailAction(Interface):
     exclude_actor = schema.Bool(
         title=_("Exclude actor from recipients"),
         description=_("Do not send the email to the user that did the action."),
-        required=False,
     )
     message = schema.Text(
         title=_("Message"),


### PR DESCRIPTION
Fixes #77 

Without this change, one can't save the mail action form without checking the field.

There is some behavior change when rendering these forms from Plone 5 to 6, but couldn't find where...