### PR TITLE
Fix RequestContainer wrapping in content rule add forms

### DIFF
--- a/news/3934.bugfix
+++ b/news/3934.bugfix
@@ -1,0 +1,2 @@
+Fix ``AttributeError: 'RequestContainer' object has no attribute 'add'`` when saving content rule actions. Use ``aq_inner`` to unwrap context.
+@jensens

--- a/src/plone/app/contentrules/browser/formhelper.py
+++ b/src/plone/app/contentrules/browser/formhelper.py
@@ -55,7 +55,7 @@ class AddForm(AutoExtensibleForm, form.AddForm):
         )
 
     def add(self, content):
-        self.context.add(content)
+        aq_inner(self.context).add(content)
 
     @button.buttonAndHandler(_("label_save", default="Save"), name="save")
     def handle_save_action(self, action):
@@ -92,7 +92,7 @@ class NullAddForm(BrowserView):
     def __call__(self):
         ob = self.create()
         notify(zope.lifecycleevent.ObjectCreatedEvent(ob))
-        self.context.add(ob)
+        aq_inner(self.context).add(ob)
         nextURL = self.nextURL()
         if nextURL:
             self.request.response.redirect(self.nextURL())

--- a/src/plone/app/contentrules/tests/test_action_notify.py
+++ b/src/plone/app/contentrules/tests/test_action_notify.py
@@ -47,6 +47,34 @@ class TestNotifyAction(ContentRulesTestCase):
         self.assertEqual("Hello world", e.message)
         self.assertEqual("info", e.message_type)
 
+    def testInvokeAddViewWithRequestContainerWrapping(self):
+        """AddForm.add() must work even when self.context is wrapped
+        in a RequestContainer (which happens during the publisher pipeline).
+        Regression test for https://github.com/plone/Products.CMFPlone/issues/3934
+        """
+        from ZPublisher.BaseRequest import RequestContainer
+
+        element = getUtility(IRuleAction, name="plone.actions.Notify")
+        storage = getUtility(IRuleStorage)
+        storage["foo"] = Rule()
+        rule = self.portal.restrictedTraverse("++rule++foo")
+
+        adding = getMultiAdapter((rule, self.request), name="+action")
+        addview = getMultiAdapter((adding, self.request), name=element.addview)
+
+        # Wrap in RequestContainer like the publisher does
+        addview.form_instance.context = adding.__of__(RequestContainer(REQUEST=self.request))
+
+        addview.form_instance.update()
+        content = addview.form_instance.create(
+            data={"message": "Wrapped test", "message_type": "warning"}
+        )
+        addview.form_instance.add(content)
+
+        e = rule.actions[0]
+        self.assertTrue(isinstance(e, NotifyAction))
+        self.assertEqual("Wrapped test", e.message)
+
     def testInvokeEditView(self):
         element = getUtility(IRuleAction, name="plone.actions.Notify")
         e = NotifyAction()

--- a/src/plone/app/contentrules/tests/test_action_notify.py
+++ b/src/plone/app/contentrules/tests/test_action_notify.py
@@ -63,7 +63,9 @@ class TestNotifyAction(ContentRulesTestCase):
         addview = getMultiAdapter((adding, self.request), name=element.addview)
 
         # Wrap in RequestContainer like the publisher does
-        addview.form_instance.context = adding.__of__(RequestContainer(REQUEST=self.request))
+        addview.form_instance.context = adding.__of__(
+            RequestContainer(REQUEST=self.request)
+        )
 
         addview.form_instance.update()
         content = addview.form_instance.create(


### PR DESCRIPTION
Use `aq_inner()` to unwrap context before calling `.add()` in `AddForm` and `NullAddForm`. When the publisher wraps context in `RequestContainer`, the `.add()` method from `RuleActionAdding` is inaccessible, causing `AttributeError`.

Includes regression test with `RequestContainer` wrapping.

Fixes plone/Products.CMFPlone#3934

🤖 Generated with [Claude Code](https://claude.com/claude-code)